### PR TITLE
Fix docker-compose.yml platform issue

### DIFF
--- a/docker/m1-mac-full/docker-compose.yml
+++ b/docker/m1-mac-full/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         VERSION: ${VERSION:-2.0-full}
         PREDOWNLOAD_MODELS: ${PREDOWNLOAD_MODELS:-true}
     
-    platform: linux/arm64  # 指定ARM64架构
+    # platform: linux/arm64  # 指定ARM64架构 - 注释掉以解决兼容性问题
     image: mineru-m1-full:${VERSION:-latest}
     container_name: mineru-full-api
     hostname: mineru-full
@@ -163,7 +163,7 @@ services:
     build:
       context: ./webui
       dockerfile: Dockerfile
-    platform: linux/arm64
+    # platform: linux/arm64  # 注释掉以解决兼容性问题
     container_name: mineru-webui
     restart: unless-stopped
     ports:

--- a/docker/m1-mac/docker-compose.yml
+++ b/docker/m1-mac/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      platform: linux/arm64  # M1芯片架构
+      # platform: linux/arm64  # M1芯片架构 - 注释掉以解决兼容性问题
     container_name: mineru-m1-api
     restart: unless-stopped
     ports:


### PR DESCRIPTION
```
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

%23%23 Motivation

This PR addresses a compatibility issue where the `platform: linux/arm64` field in `docker-compose.yml` files causes validation errors (`Additional property platform is not allowed`) on certain Docker Compose versions, especially on macOS (Apple Silicon). This field is redundant as Docker automatically detects the architecture on Apple Silicon, and its removal resolves the build/startup failure.

%23%23 Modification

- Commented out the `platform: linux/arm64` field in `docker/m1-mac/docker-compose.yml`.
- Commented out the `platform: linux/arm64` fields for the `mineru-m1` and `mineru-webui` services in `docker/m1-mac-full/docker-compose.yml`.
- Added comments to explain the changes.

%23%23 BC-breaking (Optional)

No, this modification is a bug fix that improves compatibility and does not break backward compatibility.

%23%23 Use cases (Optional)

N/A (bug fix).

%23%23 Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
```