### PR TITLE
Update PyTorch version for Apple Silicon

### DIFF
--- a/docker/m1-mac/requirements.txt
+++ b/docker/m1-mac/requirements.txt
@@ -10,9 +10,9 @@ python-multipart==0.0.6
 Pillow==10.0.1
 opencv-python-headless==4.8.1.78
 
-# 科学计算 (CPU优化版本)
-torch==2.1.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu
-torchvision==0.16.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+# 科学计算 (Apple Silicon 优化版本)
+torch==2.1.0
+torchvision==0.16.0
 
 # HTTP客户端
 httpx==0.25.2


### PR DESCRIPTION
```
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

%23%23 Motivation

This PR resolves the `ERROR: No matching distribution found for torch==2.1.0 cpu` encountered when building Docker images on Apple Silicon (ARM64) machines. The ` cpu` suffix and specific `--extra-index-url` are incompatible with Apple Silicon, which requires the standard PyTorch distribution for MPS support.

%23%23 Modification

Updated `docker/m1-mac/requirements.txt` to:
- Change `torch==2.1.0 cpu --extra-index-url https://download.pytorch.org/whl/cpu` to `torch==2.1.0`.
- Change `torchvision==0.16.0 cpu --extra-index-url https://download.pytorch.org/whl/cpu` to `torchvision==0.16.0`.
- Adjust comments to reflect Apple Silicon optimization.

%23%23 BC-breaking (Optional)

No. This change is specific to the `docker/m1-mac/requirements.txt` file and resolves a compatibility issue for Apple Silicon users without affecting x86_64 environments.

%23%23 Use cases (Optional)

- Enables successful Docker image building and execution on Apple Silicon (M1/M2/M3) Macs.
- Allows users with Apple Silicon devices to run the project within the specified Docker environment, leveraging MPS acceleration.

%23%23 Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
```